### PR TITLE
fix visitInvalidType function not impl problem.

### DIFF
--- a/lib/src/code_builder_string.dart
+++ b/lib/src/code_builder_string.dart
@@ -225,6 +225,11 @@ class DartTypeVisitor extends TypeVisitor<String> {
   String visitRecordType(Object type) {
     return "refer('record')";
   }
+
+  @override
+  String visitInvalidType(InvalidType type) {
+    return "refer('invalid')";
+  }
 }
 
 extension StringEscaped on String {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ repository: https://github.com/schultek/super_annotations
 issue_tracker: https://github.com/schultek/super_annotations/issues
 
 environment:
-  sdk: '>=2.17.0 <3.0.0'
+  sdk: '>=2.17.0 <=3.0.1'
 
 dependencies:
   analyzer: '>=4.6.0 <6.0.0'


### PR DESCRIPTION
visitInvalidType function implementation is required since dart 3.0.1