### PR TITLE
Fix relative imports on Windows

### DIFF
--- a/lib/src/imports_builder.dart
+++ b/lib/src/imports_builder.dart
@@ -1,5 +1,5 @@
 import 'package:build/build.dart';
-import 'package:path/path.dart' as path;
+import 'package:path/path.dart' as path show posix;
 
 class ImportsBuilder {
   final Set<Uri> _imports = {};
@@ -14,8 +14,8 @@ class ImportsBuilder {
 
     for (var import in _imports) {
       if (import.isScheme('asset')) {
-        var relativePath =
-            path.relative(import.path, from: path.dirname(_input.uri.path));
+        var relativePath = path.posix
+            .relative(import.path, from: path.posix.dirname(_input.uri.path));
 
         relative.add(relativePath);
       } else if (import.isScheme('package') &&
@@ -27,7 +27,7 @@ class ImportsBuilder {
             .replace(pathSegments: _input.uri.pathSegments.skip(1))
             .path;
         var relativePath =
-            path.relative(libPath, from: path.dirname(inputPath));
+            path.posix.relative(libPath, from: path.posix.dirname(inputPath));
 
         relative.add(relativePath);
       } else if (import.scheme == 'dart') {

--- a/lib/src/runner_builder.dart
+++ b/lib/src/runner_builder.dart
@@ -5,7 +5,7 @@ import 'package:analyzer/dart/constant/value.dart';
 import 'package:analyzer/dart/element/element.dart';
 import 'package:build/build.dart';
 import 'package:dart_style/dart_style.dart';
-import 'package:path/path.dart' as path;
+import 'package:path/path.dart' as path show posix;
 import 'package:source_gen/source_gen.dart';
 
 import '../super_annotations.dart';
@@ -81,7 +81,7 @@ class RunnerBuilder {
       ${imports.write()}
       
       void main(List<String> args, SendPort port) {
-        CodeGen.currentFile = '${path.basename(buildStep.inputId.path)}';
+        CodeGen.currentFile = '${path.posix.basename(buildStep.inputId.path)}';
         CodeGen.currentTarget = '${target.escaped}';
         var library = Library((l) {
           ${runBefore.map((fn) => '$fn(l);\n').join()}


### PR DESCRIPTION
Resolves #16 by explicitly using posix path separators (`/`) rather than the system default behavior.